### PR TITLE
Fix setup-seafile-mysql script on ubuntu 16.04 with mariadb.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
       - libevent-dev
       - libarchive-dev
       - intltool
-      - re2c
       - libjansson-dev
       - libonig-dev
       - libfuse-dev

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-Seafile Server Core
+Seafile Server Core [![Build Status](https://secure.travis-ci.org/haiwen/seafile-server.svg?branch=master)](http://travis-ci.org/haiwen/seafile-server)
 ============
 
 Seafile is an open source cloud storage system with features on privacy protection and teamwork. Collections of files are called libraries, and each library can be synced separately. A library can also be encrypted with a user chosen password. Seafile also allows users to create groups and easily sharing files into groups.

--- a/integration-tests/install-deps.sh
+++ b/integration-tests/install-deps.sh
@@ -13,21 +13,6 @@ wget https://dl.bintray.com/lins05/generic/libevhtp-bin/$libevhtp_bin
 tar xf $libevhtp_bin
 find $HOME/opt
 
-# download precompiled libzdb
-# zdb_bin=libzdb-bin_2.11.1.tar.gz
-# wget https://dl.bintray.com/lins05/generic/libzdb-bin/$zdb_bin
-# tar xf $zdb_bin
-# sed -i -e "s|prefix=/opt/local|prefix=$HOME/opt/local|g" $HOME/opt/local/lib/pkgconfig/zdb.pc
-# find $HOME/opt
-pushd /tmp/
-git clone --depth=1 https://github.com/haiwen/libzdb.git
-cd libzdb
-./bootstrap
-./configure --prefix=$HOME/opt/local
-make -j2
-make install
-popd
-
 # download seahub thirdpart python libs
 WGET="wget --no-check-certificate"
 downloads=$HOME/downloads

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -68,7 +68,7 @@ def prepend_env_value(name, value, seperator=':', env=None):
 
 
 def get_project_branch(project, default_branch='master'):
-    if project.name == 'seafile':
+    if project.name == 'seafile-server':
         return TRAVIS_BRANCH
     conf = json.loads(requests.get(
         'https://raw.githubusercontent.com/haiwen/seafile-test-deploy/master/branches.json').text)
@@ -117,7 +117,8 @@ class Project(object):
         tarball = glob.glob('*.tar.gz')[0]
         info('copying %s to %s', tarball, SRCDIR)
         shell('cp {} {}'.format(tarball, SRCDIR))
-        m = re.match('{}-(.*).tar.gz'.format(self.name), basename(tarball))
+        name = 'seafile' if self.name == 'seafile-server' else self.name
+        m = re.match('{}-(.*).tar.gz'.format(name), basename(tarball))
         if m:
             self.version = m.group(1)
 
@@ -126,20 +127,20 @@ class Project(object):
         shell('git checkout {}'.format(branch))
 
 
-class Ccnet(Project):
+class CcnetServer(Project):
     def __init__(self):
-        super(Ccnet, self).__init__('ccnet')
+        super(CcnetServer, self).__init__('ccnet')
 
 
-class Seafile(Project):
-    configure_cmd = './configure --enable-client --enable-server'
+class SeafileServer(Project):
+    configure_cmd = './configure'
 
     def __init__(self):
-        super(Seafile, self).__init__('seafile')
+        super(SeafileServer, self).__init__('seafile-server')
 
     @chdir
     def copy_dist(self):
-        super(Seafile, self).copy_dist()
+        super(SeafileServer, self).copy_dist()
         global seafile_version
         seafile_version = self.version
 
@@ -181,7 +182,7 @@ class SeafObj(Project):
 def build_server(libsearpc, ccnet, seafile):
     cmd = [
         'python',
-        join(TOPDIR, 'seafile/scripts/build/build-server.py'),
+        join(TOPDIR, 'seafile-server/scripts/build/build-server.py'),
         '--yes',
         '--version=%s' % seafile.version,
         '--libsearpc_version=%s' % libsearpc.version,
@@ -196,14 +197,14 @@ def build_server(libsearpc, ccnet, seafile):
 
 def fetch_and_build():
     libsearpc = Project('libsearpc')
-    ccnet = Ccnet()
-    seafile = Seafile()
+    ccnet = CcnetServer()
+    seafile = SeafileServer()
     seahub = Seahub()
     seafobj = SeafObj()
     seafdav = SeafDAV()
 
     for project in (libsearpc, ccnet, seafile, seahub, seafdav, seafobj):
-        if project.name != 'seafile':
+        if project.name != 'seafile-server':
             project.clone()
         project.copy_dist()
 

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -30,7 +30,7 @@ TRAVIS_BRANCH = os.environ.get('TRAVIS_BRANCH', 'master')
 def make_build_env():
     env = dict(os.environ)
     libsearpc_dir = abspath(join(TOPDIR, 'libsearpc'))
-    ccnet_dir = abspath(join(TOPDIR, 'ccnet'))
+    ccnet_dir = abspath(join(TOPDIR, 'ccnet-server'))
 
     def _env_add(*a, **kw):
         kw['env'] = env
@@ -117,7 +117,12 @@ class Project(object):
         tarball = glob.glob('*.tar.gz')[0]
         info('copying %s to %s', tarball, SRCDIR)
         shell('cp {} {}'.format(tarball, SRCDIR))
-        name = 'seafile' if self.name == 'seafile-server' else self.name
+        if self.name == 'seafile-server':
+            name = 'seafile'
+        elif self.name == 'ccnet-server':
+            name = 'ccnet'
+        else:
+            name = self.name
         m = re.match('{}-(.*).tar.gz'.format(name), basename(tarball))
         if m:
             self.version = m.group(1)
@@ -129,7 +134,7 @@ class Project(object):
 
 class CcnetServer(Project):
     def __init__(self):
-        super(CcnetServer, self).__init__('ccnet')
+        super(CcnetServer, self).__init__('ccnet-server')
 
 
 class SeafileServer(Project):
@@ -297,4 +302,6 @@ def setup_and_test(db, initmode):
 
 if __name__ == '__main__':
     os.chdir(TOPDIR)
+    # Add the location where libevhtp is installed so ldd can know it.
+    prepend_env_value('LD_LIBRARY_PATH', os.path.expanduser('~/opt/local/lib'))
     main()


### PR DESCRIPTION
* For MariaDB on Ubuntu 16.04, the msyql root user can only be
  accessed from localhost with unix socket. So we retry with
  localhost when failing with 127.0.0.1.

* Also we add restriction to disallow using mysql "root" user in
  ccnet/seafile/seahub configuraiton. It provides both secuirty
  hardening, and also fixes the mariadb problem mentioned above.