### PR TITLE
Change case for old logdir option -L --> -l

### DIFF
--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -926,7 +926,7 @@ int main (int argc, char **argv)
         case 'f':
             daemon_mode = 0;
             break;
-        case 'L':
+        case 'l':
             logdir = g_strdup(optarg);
             break;
         case 'g':


### PR DESCRIPTION
This will fix seafile-controller when calling the logdir option option -l