### PR TITLE
fixed checks and exit codes for running service components

### DIFF
--- a/scripts/seahub.sh
+++ b/scripts/seahub.sh
@@ -231,10 +231,12 @@ function stop_seahub () {
         pid=$(cat "${pidfile}")
         echo "Stopping seahub ..."
         kill ${pid}
+        sleep 1
+        kill -0 $pid &>/dev/null && echo "Error: seahub is still running, pid $pid. You can try to force kill it with 'kill -9 $pid; rm -f $pidfile'." >&2 && exit 1
         rm -f ${pidfile}
-        return 0
     else
         echo "Seahub is not running"
+                exit 1
     fi
 }
 


### PR DESCRIPTION
I patched `seafile.sh` and `seahub.sh` to properly check for running service components and exit with correct error codes (so that other scripts can correctly detect stsrt/stop failures), as commented in this issue https://github.com/haiwen/seafile/issues/1835

Keep up the good work!