### PR TITLE
Fix setup-seafile-mysql.py: env vars are not used if only argument is…

### DIFF
--- a/scripts/setup-seafile-mysql.py
+++ b/scripts/setup-seafile-mysql.py
@@ -1368,7 +1368,7 @@ def check_params(args):
 
 
 def main():
-    if len(sys.argv) > 2 and sys.argv[1] == 'auto':
+    if len(sys.argv) >= 2 and sys.argv[1] == 'auto':
         sys.argv.remove('auto')
         parser = argparse.ArgumentParser()
         parser.add_argument('-n', '--server-name', help='server name')


### PR DESCRIPTION
… 'auto'

- environement variables should be used also when no command line args were provided,
  ie when only argument to script is 'auto';