### PR TITLE
Use more threads for each gunicorn process.

### DIFF
--- a/scripts/seahub.conf
+++ b/scripts/seahub.conf
@@ -2,6 +2,7 @@ import os
 
 daemon = True
 workers = 3
+threads = 5
 
 # Logging
 runtime_dir = os.path.dirname(__file__)


### PR DESCRIPTION
**Note**: need to include the python "futures" library when packaging seafile server.