### PR TITLE
have seahub version reflect VERSION instead of SEAFILE_VERSION

### DIFF
--- a/scripts/build/build-server.py
+++ b/scripts/build/build-server.py
@@ -246,7 +246,7 @@ class Seahub(Project):
         ]
 
     def get_version(self):
-        return conf[CONF_SEAFILE_VERSION]
+        return conf[CONF_VERSION]
 
     def build(self):
         self.write_version_to_settings_py()
@@ -343,7 +343,7 @@ def validate_args(usage, options):
     check_targz_src('libsearpc', libsearpc_version, srcdir)
     check_targz_src('ccnet', ccnet_version, srcdir)
     check_targz_src('seafile', seafile_version, srcdir)
-    check_targz_src('seahub', seafile_version, srcdir)
+    check_targz_src('seahub', version, srcdir)
     check_targz_src_no_version('seafdav', srcdir)
     check_targz_src_no_version('seafobj', srcdir)
 


### PR DESCRIPTION
so that build-server.py will use seahub version from --version instead of inheriting it from --seafile_version