### PR TITLE
Update seafile-admin to fit with the django 1.11

### DIFF
--- a/tools/seafile-admin
+++ b/tools/seafile-admin
@@ -499,7 +499,7 @@ def init_seahub():
     # create seahub_settings.py
     create_seahub_settings_py()
 
-    argv = [PYTHON, 'manage.py', 'syncdb']
+    argv = [PYTHON, 'manage.py', 'migrate']
     # Set proper PYTHONPATH before run django syncdb command
     env = get_seahub_env()
 
@@ -518,10 +518,10 @@ def init_seahub():
 
 
 def check_django_version():
-    '''Requires django 1.8'''
+    '''Requires django 1.11'''
     import django
-    if django.VERSION[0] != 1 or django.VERSION[1] != 8:
-        error('Django 1.8 is required')
+    if django.VERSION[0] != 1 or django.VERSION[1] != 11:
+        error('Django 1.11 is required')
     del django
 
 


### PR DESCRIPTION
Update the check_django_version to 1.11 (change in seafile 6.3)
Django syncdb command is depreciated since version 1.7. It is now recommanded to use migrate (https://docs.djangoproject.com/en/1.7/ref/django-admin/#syncdb)