### PR TITLE
seafile-admin: Require Django 1.8+ instead of 1.8

### DIFF
--- a/tools/seafile-admin
+++ b/tools/seafile-admin
@@ -518,10 +518,10 @@ def init_seahub():
 
 
 def check_django_version():
-    '''Requires django 1.8'''
+    '''Requires django >= 1.8'''
     import django
-    if django.VERSION[0] != 1 or django.VERSION[1] != 8:
-        error('Django 1.8 is required')
+    if django.VERSION[0] != 1 or django.VERSION[1] < 8:
+        error('Django 1.8+ is required')
     del django
 
 


### PR DESCRIPTION
New Seahub requre Django 1.11 so allow to use Django 1.11 in seafile-admin script