### PR TITLE
fixed typo in getopt

### DIFF
--- a/scripts/setup-seafile.sh
+++ b/scripts/setup-seafile.sh
@@ -354,7 +354,7 @@ function copy_user_manuals() {
 }
 
 function parse_params() {
-    while getopts n:i:p:d arg; do
+    while getopts n:i:p:d: arg; do
         case $arg in
             n)
                 server_name=${OPTARG}


### PR DESCRIPTION
because of missing ':',  -d param was ignored