### PR TITLE
Connection to Mysql server only Unix socket

### DIFF
--- a/common/seaf-db.c
+++ b/common/seaf-db.c
@@ -539,13 +539,13 @@ mysql_db_new (const char *host,
 {
     MySQLDB *db = g_new0 (MySQLDB, 1);
 
-    db->host = g_strdup (host);
+    if (host) {db->host = g_strdup (host);} else {db->host = NULL;}
     db->user = g_strdup (user);
     db->password = g_strdup (password);
     db->port = port;
     db->db_name = g_strdup(db_name);
-    db->unix_socket = g_strdup(unix_socket);
-    db->use_ssl = use_ssl;
+    if (unix_socket) {db->unix_socket = g_strdup(unix_socket);} else {db->unix_socket = NULL;}
+    if (use_ssl) {db->use_ssl = use_ssl;} else {db->use_ssl = NULL;}
     db->charset = g_strdup(charset);
 
     mysql_library_init (0, NULL, NULL);

--- a/common/seaf-utils.c
+++ b/common/seaf-utils.c
@@ -68,11 +68,7 @@ mysql_db_start (SeafileSession *session)
     GError *error = NULL;
 
     host = seaf_key_file_get_string (session->config, "database", "host", &error);
-    if (!host) {
-        seaf_warning ("DB host not set in config.\n");
-        return -1;
-    }
-
+  
     port = g_key_file_get_integer (session->config, "database", "port", &error);
     if (error) {
         port = MYSQL_DEFAULT_PORT;
@@ -111,7 +107,13 @@ mysql_db_start (SeafileSession *session)
     if (max_connections <= 0)
         max_connections = DEFAULT_MAX_CONNECTIONS;
 
-    session->db = seaf_db_new_mysql (host, port, user, passwd, db, unix_socket, use_ssl, charset, max_connections);
+    if (unix_socket) {session->db = seaf_db_new_mysql (NULL, 0, user, passwd, db, unix_socket, NULL, charset, max_connections);}
+       else if (host) {session->db = seaf_db_new_mysql (host, port, user, passwd, db, NULL, use_ssl, charset, max_connections);}
+               else {
+                   g_warning ("DB host or socket not set in config.\n");
+                   return -1;
+               }
+
     if (!session->db) {
         seaf_warning ("Failed to start mysql db.\n");
         return -1;


### PR DESCRIPTION
Support connection to Mysql server only Unix socket
Example:
seafile.conf
[database]
type=mysql
db_name=seafile_db
user=seafile/
password=secret
unix_socket=/var/run/mysqld/mysqld.sock
port=0
connection_charset = utf8

ccnet.conf
[Database]
ENGINE=mysql
DB=ccnet_db
USER=seafile
PASSWD=secret
UNIX_SOCKET=/var/run/mysqld/mysqld.sock
PORT=0
CONNECTION_CHARSET = utf8

seahub_settings.py
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.mysql',
        'NAME': 'seahub_db',
        'USER': 'seafile',
        'PASSWORD': 'secret',
        'HOST':'/var/run/mysqld/mysqld.sock'
    }
}
