### PR TITLE
allow superuser creation without password prompt

### DIFF
--- a/scripts/reset-admin.sh
+++ b/scripts/reset-admin.sh
@@ -51,4 +51,7 @@ export PYTHONPATH=${INSTALLPATH}/seafile/lib/python3.6/site-packages:${INSTALLPA
 export SEAFILE_RPC_PIPE_PATH=${INSTALLPATH}/runtime
 
 manage_py=${INSTALLPATH}/seahub/manage.py
-exec "$PYTHON" "$manage_py" createsuperuser
+[ ! -z $DJANGO_SUPERUSER_EMAIL ] && ARGS="--email ${DJANGO_SUPERUSER_EMAIL}"
+[ ! -z $DJANGO_SUPERUSER_USERNAME ] && ARGS="${ARGS} --username ${DJANGO_SUPERUSER_USERNAME}"
+[ ! -z $DJANGO_SUPERUSER_PASSWORD ] && ARGS="${ARGS} --password ${DJANGO_SUPERUSER_PASSWORD}"
+exec "$PYTHON" "$manage_py" createsuperuser ${ARGS}


### PR DESCRIPTION
This patch in combination with pull request https://github.com/haiwen/seahub/pull/4832 adds the option to add a seafile admin user (django superuser) without any prompts (mainly password prompt, because the currently used Django version (2.2.17) in Seafile 8.0.3 won't allow this otherweise).