### PR TITLE
Add UNIQUE index on VirtualRepo to prevent duplicates

### DIFF
--- a/scripts/sql/mysql/seafile.sql
+++ b/scripts/sql/mysql/seafile.sql
@@ -306,7 +306,8 @@ CREATE TABLE IF NOT EXISTS VirtualRepo (
   path TEXT,
   base_commit CHAR(40),
   UNIQUE INDEX(repo_id),
-  INDEX(origin_repo)
+  INDEX(origin_repo),
+  UNIQUE INDEX(origin_repo,path)
 ) ENGINE=INNODB;
 
 CREATE TABLE IF NOT EXISTS WebAP (

--- a/scripts/sql/sqlite/seafile.sql
+++ b/scripts/sql/sqlite/seafile.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS RepoValidSince (repo_id CHAR(37) PRIMARY KEY, timesta
 CREATE TABLE IF NOT EXISTS WebAP (repo_id CHAR(37) PRIMARY KEY, access_property CHAR(10));
 CREATE TABLE IF NOT EXISTS VirtualRepo (repo_id CHAR(36) PRIMARY KEY, origin_repo CHAR(36), path TEXT, base_commit CHAR(40));
 CREATE INDEX IF NOT EXISTS virtualrepo_origin_repo_idx ON VirtualRepo (origin_repo);
+CREATE INDEX IF NOT EXISTS virtualrepo_unique_idx ON VirtualRepo (origin_repo, path);
 CREATE TABLE IF NOT EXISTS GarbageRepos (repo_id CHAR(36) PRIMARY KEY);
 CREATE TABLE IF NOT EXISTS RepoTrash (repo_id CHAR(36) PRIMARY KEY, repo_name VARCHAR(255), head_id CHAR(40), owner_id VARCHAR(255), size BIGINT UNSIGNED, org_id INTEGER, del_time BIGINT);
 CREATE INDEX IF NOT EXISTS repotrash_owner_id_idx ON RepoTrash(owner_id);

--- a/scripts/upgrade/sql/8.1.0/mysql/seafile.sql
+++ b/scripts/upgrade/sql/8.1.0/mysql/seafile.sql
@@ -1,0 +1,1 @@
+ALTER TABLE VirtualRepo ADD UNIQUE INDEX(origin_repo,path);

--- a/scripts/upgrade/sql/8.1.0/sqlite3/seafile.sql
+++ b/scripts/upgrade/sql/8.1.0/sqlite3/seafile.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "virtualrepo_unique_idx" ON "VirtualRepo" ("origin_repo", "path");

--- a/server/repo-mgr.c
+++ b/server/repo-mgr.c
@@ -1039,8 +1039,8 @@ create_tables_mysql (SeafRepoManager *mgr)
 
     sql = "CREATE TABLE IF NOT EXISTS VirtualRepo (id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT, "
         "repo_id CHAR(36),"
-        "origin_repo CHAR(36), path TEXT, base_commit CHAR(40), UNIQUE INDEX(repo_id), INDEX(origin_repo))"
-        "ENGINE=INNODB";
+        "origin_repo CHAR(36), path TEXT, base_commit CHAR(40), UNIQUE INDEX(repo_id), INDEX(origin_repo)), "
+	"UNIQUE INDEX(origin_repo,path) ENGINE=INNODB";
     if (seaf_db_query (db, sql) < 0)
         return -1;
 
@@ -1192,6 +1192,11 @@ create_tables_sqlite (SeafRepoManager *mgr)
 
     sql = "CREATE INDEX IF NOT EXISTS virtualrepo_origin_repo_idx "
         "ON VirtualRepo (origin_repo)";
+    if (seaf_db_query (db, sql) < 0)
+        return -1;
+
+    sql = "CREATE INDEX IF NOT EXISTS virtualrepo_unique_idx "
+        "ON VirtualRepo (origin_repo, path)";
     if (seaf_db_query (db, sql) < 0)
         return -1;
 


### PR DESCRIPTION
While the code currently verifies whether an entry exists in the VirtualRepo table before creating a new one, it is possible that bugs in the code (such as race conditions) could result in extraneous entries in the table.
This change enforces the entries within the table be unique, preventing the existing of a duplicate entry even if other areas of the code have bugs.

This change does not implement an appropriate migration for the case where a server already has duplicate entries in the VirtualRepo table that would cause the constraint to fail to be added.

This is a partial fix for haiwen/seafile#2449.