### PR TITLE
WIP: Adjust for libevhtp 1.2.12 and later

### DIFF
--- a/server/upload-file.c
+++ b/server/upload-file.c
@@ -2231,7 +2231,8 @@ out:
         /* Set keepalive to 0. This will cause evhtp to close the
          * connection after sending the reply.
          */
-        req->keepalive = 0;
+        // req->keepalive = 0;
+evhtp_request_set_keepalive(req, 0);
 
         fsm->state = RECV_ERROR;
     }
@@ -2532,8 +2533,8 @@ upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
     }
 
     /* Set up per-request hooks, so that we can read file data piece by piece. */
-    evhtp_set_hook (&req->hooks, evhtp_hook_on_read, upload_read_cb, fsm);
-    evhtp_set_hook (&req->hooks, evhtp_hook_on_request_fini, upload_finish_cb, fsm);
+    evhtp_request_set_hook (req, evhtp_hook_on_read, upload_read_cb, fsm);
+    evhtp_request_set_hook (req, evhtp_hook_on_request_fini, upload_finish_cb, fsm);
     /* Set arg for upload_cb or update_cb. */
     req->cbarg = fsm;
 
@@ -2548,7 +2549,8 @@ err:
     /* Set keepalive to 0. This will cause evhtp to close the
      * connection after sending the reply.
      */
-    req->keepalive = 0;
+    //req->keepalive = 0;
+    evhtp_request_set_keepalive(req, 0);
     send_error_reply (req, EVHTP_RES_BADREQ, err_msg);
 
     g_free (repo_id);
@@ -2649,32 +2651,32 @@ upload_file_init (evhtp_t *htp, const char *http_temp_dir)
     g_free (cluster_shared_dir);
 
     cb = evhtp_set_regex_cb (htp, "^/upload-api/.*", upload_api_cb, NULL);
-    evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
+    evhtp_callback_set_hook(cb, evhtp_hook_on_headers, upload_headers_cb, NULL);
 
     cb = evhtp_set_regex_cb (htp, "^/upload-raw-blks-api/.*",
                              upload_raw_blks_api_cb, NULL);
-    evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
+    evhtp_callback_set_hook(cb, evhtp_hook_on_headers, upload_headers_cb, NULL);
 
     cb = evhtp_set_regex_cb (htp, "^/upload-blks-api/.*", upload_blks_api_cb, NULL);
-    evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
+    evhtp_callback_set_hook(cb, evhtp_hook_on_headers, upload_headers_cb, NULL);
 
     /* cb = evhtp_set_regex_cb (htp, "^/upload-blks-aj/.*", upload_blks_ajax_cb, NULL); */
     /* evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL); */
 
     cb = evhtp_set_regex_cb (htp, "^/upload-aj/.*", upload_ajax_cb, NULL);
-    evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
+    evhtp_callback_set_hook(cb, evhtp_hook_on_headers, upload_headers_cb, NULL);
 
     cb = evhtp_set_regex_cb (htp, "^/update-api/.*", update_api_cb, NULL);
-    evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
+    evhtp_callback_set_hook(cb, evhtp_hook_on_headers, upload_headers_cb, NULL);
 
     cb = evhtp_set_regex_cb (htp, "^/update-blks-api/.*", update_blks_api_cb, NULL);
-    evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
+    evhtp_callback_set_hook(cb, evhtp_hook_on_headers, upload_headers_cb, NULL);
 
     /* cb = evhtp_set_regex_cb (htp, "^/update-blks-aj/.*", update_blks_ajax_cb, NULL); */
     /* evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL); */
 
     cb = evhtp_set_regex_cb (htp, "^/update-aj/.*", update_ajax_cb, NULL);
-    evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
+    evhtp_callback_set_hook(cb, evhtp_hook_on_headers, upload_headers_cb, NULL);
 
     evhtp_set_regex_cb (htp, "^/upload_progress.*", upload_progress_cb, NULL);
 


### PR DESCRIPTION
- set_hook is deprecated in libevhtp-1.2.12 and later,  which advice to use evhtp_[connection|request|callback]_set_hook()  instead of set_hook directly
- first argument is evhtp_request_t* or evhtp_callback_t* instead of  evhtp_hooks_t **
- evhtp_request_set_keepalive() instead of deprecated direct reference.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>