### PR TITLE
illumos: syscall.Dup3 not implemented in go for solaris

### DIFF
--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -437,7 +437,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to open or create error log file: %v", err)
 		}
-		syscall.Dup3(int(fp.Fd()), int(os.Stderr.Fd()), 0)
+		syscall.Syscall(syscall.SYS_FCNTL, fp.Fd(), syscall.F_DUP2FD, os.Stderr.Fd())
 	}
 
 	repomgr.Init(seafileDB)


### PR DESCRIPTION
In the go programming language Dup2 and Dup3 are not implemented for solaris
(aka illumos) based operating systems. As long as this is not provided by go
a workaround would be suitable.

As the return of dup3() syscall is not used dup2() could be used. which is
could be workarounded by using the syscall.Syscall implementation.