### PR TITLE
Setup mysql connection_max_life_time.

### DIFF
--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gorilla/mux"
@@ -152,6 +153,18 @@ func loadCcnetDB() {
 		if key, err = section.GetKey("USE_SSL"); err == nil {
 			useTLS, _ = key.Bool()
 		}
+		var connMaxLifeTimeSec int64 = 60 * 3
+		if key, err = section.GetKey("CONN_MAX_LIFE_TIME_SEC"); err == nil {
+			connMaxLifeTimeSec, _ = key.Int64()
+		}
+		maxOpenConns := 100
+		if key, err = section.GetKey("MAX_OPEN_CONNS"); err == nil {
+			maxOpenConns, _ = key.Int()
+		}
+		maxIdleConns := 10
+		if key, err = section.GetKey("MAX_IDLE_CONNS"); err == nil {
+			maxIdleConns, _ = key.Int()
+		}
 		var dsn string
 		if unixSocket == "" {
 			dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=%t", user, password, host, port, dbName, useTLS)
@@ -162,6 +175,9 @@ func loadCcnetDB() {
 		if err != nil {
 			log.Fatalf("Failed to open database: %v", err)
 		}
+		ccnetDB.SetConnMaxLifetime(time.Second * time.Duration(connMaxLifeTimeSec))
+		ccnetDB.SetMaxOpenConns(maxOpenConns)
+		ccnetDB.SetMaxIdleConns(maxIdleConns)
 	} else if strings.EqualFold(dbEngine, "sqlite") {
 		ccnetDBPath := filepath.Join(centralDir, "groupmgr.db")
 		ccnetDB, err = sql.Open("sqlite3", ccnetDBPath)
@@ -220,6 +236,18 @@ func loadSeafileDB() {
 		if key, err = section.GetKey("use_ssl"); err == nil {
 			useTLS, _ = key.Bool()
 		}
+		var connMaxLifeTimeSec int64 = 60 * 3
+		if key, err = section.GetKey("CONN_MAX_LIFE_TIME_SEC"); err == nil {
+			connMaxLifeTimeSec, _ = key.Int64()
+		}
+		maxOpenConns := 100
+		if key, err = section.GetKey("MAX_OPEN_CONNS"); err == nil {
+			maxOpenConns, _ = key.Int()
+		}
+		maxIdleConns := 10
+		if key, err = section.GetKey("MAX_IDLE_CONNS"); err == nil {
+			maxIdleConns, _ = key.Int()
+		}
 
 		var dsn string
 		if unixSocket == "" {
@@ -232,6 +260,9 @@ func loadSeafileDB() {
 		if err != nil {
 			log.Fatalf("Failed to open database: %v", err)
 		}
+		seafileDB.SetConnMaxLifetime(time.Second * time.Duration(connMaxLifeTimeSec))
+		seafileDB.SetMaxOpenConns(maxOpenConns)
+		seafileDB.SetMaxIdleConns(maxIdleConns)
 	} else if strings.EqualFold(dbEngine, "sqlite") {
 		seafileDBPath := filepath.Join(absDataDir, "seafile.db")
 		seafileDB, err = sql.Open("sqlite3", seafileDBPath)


### PR DESCRIPTION
During uploading, the uploading progress will be aborted when the mysql server close the timeouted connetion. We add the maxLifeTime setting to let the mysql driver handle this.

refence: https://github.com/go-sql-driver/mysql#important-settings