### PR TITLE
Use socket-authentification for mysql

### DIFF
--- a/common/seaf-db.c
+++ b/common/seaf-db.c
@@ -844,6 +844,13 @@ mysql_db_get_connection (SeafDB *vdb)
 
     if (db->charset)
         mysql_options(db_conn, MYSQL_SET_CHARSET_NAME, db->charset);
+    if (db->unix_socket)
+    {
+        mysql_options (db_conn, MYSQL_OPT_PROTOCOL, MYSQL_PROTOCOL_SOCKET);
+        if (!db->user) {
+            mysql_options (db_conn, MYSQL_DEFAULT_AUTH, "unix_socket");
+        }
+    }
 
     mysql_options(db_conn, MYSQL_OPT_CONNECT_TIMEOUT, (const char*)&conn_timeout);
     mysql_options(db_conn, MYSQL_OPT_READ_TIMEOUT, (const char*)&read_write_timeout);

--- a/common/seaf-utils.c
+++ b/common/seaf-utils.c
@@ -67,8 +67,12 @@ mysql_db_start (SeafileSession *session)
     int max_connections = 0;
     GError *error = NULL;
 
+    // Check unix_socket first. host, user and passwd are not needed if set.
+    unix_socket = seaf_key_file_get_string (session->config, 
+                                         "database", "unix_socket", NULL);
+
     host = seaf_key_file_get_string (session->config, "database", "host", &error);
-    if (!host) {
+    if (!host && !unix_socket) {
         seaf_warning ("DB host not set in config.\n");
         return -1;
     }
@@ -79,13 +83,13 @@ mysql_db_start (SeafileSession *session)
     }
 
     user = seaf_key_file_get_string (session->config, "database", "user", &error);
-    if (!user) {
+    if (!user && !unix_socket) {
         seaf_warning ("DB user not set in config.\n");
         return -1;
     }
 
     passwd = seaf_key_file_get_string (session->config, "database", "password", &error);
-    if (!passwd) {
+    if (!passwd && !unix_socket) {
         seaf_warning ("DB passwd not set in config.\n");
         return -1;
     }
@@ -95,9 +99,6 @@ mysql_db_start (SeafileSession *session)
         seaf_warning ("DB name not set in config.\n");
         return -1;
     }
-
-    unix_socket = seaf_key_file_get_string (session->config, 
-                                         "database", "unix_socket", NULL);
 
     use_ssl = g_key_file_get_boolean (session->config,
                                       "database", "use_ssl", NULL);
@@ -270,20 +271,23 @@ ccnet_init_mysql_database (SeafileSession *session)
     char *ca_path = NULL;
     int max_connections = 0;
 
+    // Check unix_socket first. host, user and passwd are not needed if set.
+    unix_socket = ccnet_key_file_get_string (session->ccnet_config,
+                                             "Database", "UNIX_SOCKET");
     host = ccnet_key_file_get_string (session->ccnet_config, "Database", "HOST");
     user = ccnet_key_file_get_string (session->ccnet_config, "Database", "USER");
     passwd = ccnet_key_file_get_string (session->ccnet_config, "Database", "PASSWD");
     db = ccnet_key_file_get_string (session->ccnet_config, "Database", "DB");
 
-    if (!host) {
+    if (!host && !unix_socket) {
         seaf_warning ("DB host not set in config.\n");
         return -1;
     }
-    if (!user) {
+    if (!user && !unix_socket) {
         seaf_warning ("DB user not set in config.\n");
         return -1;
     }
-    if (!passwd) {
+    if (!passwd && !unix_socket) {
         seaf_warning ("DB passwd not set in config.\n");
         return -1;
     }
@@ -299,8 +303,6 @@ ccnet_init_mysql_database (SeafileSession *session)
         port = MYSQL_DEFAULT_PORT;
     }
 
-    unix_socket = ccnet_key_file_get_string (session->ccnet_config,
-                                             "Database", "UNIX_SOCKET");
     use_ssl = g_key_file_get_boolean (session->ccnet_config, "Database", "USE_SSL", NULL);
     skip_verify = g_key_file_get_boolean (session->ccnet_config, "Database", "SKIP_VERIFY", NULL);
     if (use_ssl && !skip_verify) {

--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -91,18 +91,29 @@ func loadCcnetDB() {
 	}
 
 	if strings.EqualFold(dbEngine, "mysql") {
-		if key, err = section.GetKey("HOST"); err != nil {
+		// Check unix_socket first. host, user and password are not needed if set.
+		unixSocket := ""
+		if key, err = section.GetKey("UNIX_SOCKET"); err == nil {
+			unixSocket = key.String()
+		}
+		host := ""
+		if key, err = section.GetKey("HOST"); err == nil {
+			host = key.String()
+		} else if unixSocket == "" {
 			log.Fatal("No database host in ccnet.conf.")
 		}
-		host := key.String()
-		if key, err = section.GetKey("USER"); err != nil {
+		user := ""
+		if key, err = section.GetKey("USER"); err == nil {
+			user = key.String()
+		} else if unixSocket == "" {
 			log.Fatal("No database user in ccnet.conf.")
 		}
-		user := key.String()
-		if key, err = section.GetKey("PASSWD"); err != nil {
+		password := ""
+		if key, err = section.GetKey("PASSWORD"); err == nil {
+			password = key.String()
+		} else if unixSocket == "" {
 			log.Fatal("No database password in ccnet.conf.")
 		}
-		password := key.String()
 		if key, err = section.GetKey("DB"); err != nil {
 			log.Fatal("No database db_name in ccnet.conf.")
 		}
@@ -110,10 +121,6 @@ func loadCcnetDB() {
 		port := 3306
 		if key, err = section.GetKey("PORT"); err == nil {
 			port, _ = key.Int()
-		}
-		unixSocket := ""
-		if key, err = section.GetKey("UNIX_SOCKET"); err == nil {
-			unixSocket = key.String()
 		}
 		useTLS := false
 		if key, err = section.GetKey("USE_SSL"); err == nil {
@@ -138,7 +145,11 @@ func loadCcnetDB() {
 				dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=%t", user, password, host, port, dbName, useTLS)
 			}
 		} else {
-			dsn = fmt.Sprintf("%s:%s@unix(%s)/%s", user, password, unixSocket, dbName)
+			if user != "" {
+				dsn = fmt.Sprintf("%s:%s@unix(%s)/%s", user, password, unixSocket, dbName)
+			} else {
+				dsn = fmt.Sprintf("unix(%s)/%s", unixSocket, dbName)
+			}
 		}
 		ccnetDB, err = sql.Open("mysql", dsn)
 		if err != nil {
@@ -191,18 +202,29 @@ func loadSeafileDB() {
 		dbEngine = key.String()
 	}
 	if strings.EqualFold(dbEngine, "mysql") {
-		if key, err = section.GetKey("host"); err != nil {
+		// Check unix_socket first. host, user and password are not needed if set.
+		unixSocket := ""
+		if key, err = section.GetKey("unix_socket"); err == nil {
+			unixSocket = key.String()
+		}
+		host := ""
+		if key, err = section.GetKey("host"); err == nil {
+			host = key.String()
+		} else if unixSocket == "" {
 			log.Fatal("No database host in seafile.conf.")
 		}
-		host := key.String()
-		if key, err = section.GetKey("user"); err != nil {
+		user := ""
+		if key, err = section.GetKey("user"); err == nil {
+			user = key.String()
+		} else if unixSocket == "" {
 			log.Fatal("No database user in seafile.conf.")
 		}
-		user := key.String()
-		if key, err = section.GetKey("password"); err != nil {
+		password := ""
+		if key, err = section.GetKey("password"); err == nil {
+			password = key.String()
+		} else if unixSocket == "" {
 			log.Fatal("No database password in seafile.conf.")
 		}
-		password := key.String()
 		if key, err = section.GetKey("db_name"); err != nil {
 			log.Fatal("No database db_name in seafile.conf.")
 		}
@@ -210,10 +232,6 @@ func loadSeafileDB() {
 		port := 3306
 		if key, err = section.GetKey("port"); err == nil {
 			port, _ = key.Int()
-		}
-		unixSocket := ""
-		if key, err = section.GetKey("unix_socket"); err == nil {
-			unixSocket = key.String()
 		}
 		useTLS := false
 		if key, err = section.GetKey("use_ssl"); err == nil {
@@ -239,7 +257,11 @@ func loadSeafileDB() {
 				dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=%t", user, password, host, port, dbName, useTLS)
 			}
 		} else {
-			dsn = fmt.Sprintf("%s:%s@unix(%s)/%s", user, password, unixSocket, dbName)
+			if user != "" {
+				dsn = fmt.Sprintf("%s:%s@unix(%s)/%s", user, password, unixSocket, dbName)
+			} else {
+				dsn = fmt.Sprintf("unix(%s)/%s", unixSocket, dbName)
+			}
 		}
 
 		seafileDB, err = sql.Open("mysql", dsn)

--- a/notification-server/server.go
+++ b/notification-server/server.go
@@ -104,18 +104,29 @@ func loadCcnetDB() {
 		log.Fatalf("Unsupported database %s.", dbEngine)
 	}
 
-	if key, err = section.GetKey("HOST"); err != nil {
+	// Check unix_socket first. host, user and password are not needed if set.
+	unixSocket := ""
+	if key, err = section.GetKey("UNIX_SOCKET"); err == nil {
+		unixSocket = key.String()
+	}
+	host := ""
+	if key, err = section.GetKey("HOST"); err == nil {
+		host = key.String()
+	} else if unixSocket == "" {
 		log.Fatal("No database host in ccnet.conf.")
 	}
-	host := key.String()
-	if key, err = section.GetKey("USER"); err != nil {
+	user := ""
+	if key, err = section.GetKey("USER"); err == nil {
+		user = key.String()
+	} else if unixSocket == "" {
 		log.Fatal("No database user in ccnet.conf.")
 	}
-	user := key.String()
-	if key, err = section.GetKey("PASSWD"); err != nil {
+	password := ""
+	if key, err = section.GetKey("PASSWORD"); err == nil {
+		password = key.String()
+	} else if unixSocket == "" {
 		log.Fatal("No database password in ccnet.conf.")
 	}
-	password := key.String()
 	if key, err = section.GetKey("DB"); err != nil {
 		log.Fatal("No database db_name in ccnet.conf.")
 	}
@@ -123,10 +134,6 @@ func loadCcnetDB() {
 	port := 3306
 	if key, err = section.GetKey("PORT"); err == nil {
 		port, _ = key.Int()
-	}
-	unixSocket := ""
-	if key, err = section.GetKey("UNIX_SOCKET"); err == nil {
-		unixSocket = key.String()
 	}
 	useTLS := false
 	if key, err = section.GetKey("USE_SSL"); err == nil {
@@ -136,7 +143,11 @@ func loadCcnetDB() {
 	if unixSocket == "" {
 		dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=%t", user, password, host, port, dbName, useTLS)
 	} else {
-		dsn = fmt.Sprintf("%s:%s@unix(%s)/%s", user, password, unixSocket, dbName)
+		if user != "" {
+			dsn = fmt.Sprintf("%s:%s@unix(%s)/%s", user, password, unixSocket, dbName)
+		} else {
+			dsn = fmt.Sprintf("unix(%s)/%s", unixSocket, dbName)
+		}
 	}
 	ccnetDB, err = sql.Open("mysql", dsn)
 	if err != nil {


### PR DESCRIPTION
It's recommended to use unix-sockets to connect to mysql/mariaDB. Sadly this feature is broken in seafile-server, so here is a fix for this.

fixes haiwen/seafile#2590


- When a unix-socket is set ...
  - allow host, user and password to be empty.
  - prefer unix-socket over TCP
- When no user is set, use socket-authentication automatic.