### PR TITLE
configure: properly install in Python 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,7 +269,7 @@ AC_SUBST(JWT_CFLAGS)
 AC_SUBST(JWT_LIBS)
 
 if test x${compile_python} = xyes; then
-    AM_PATH_PYTHON([2.6])
+    AM_PATH_PYTHON([3.5])
     if test "$bwin32" = true; then
         if test x$PYTHON_DIR != x; then
             # set pyexecdir to somewhere like /c/Python26/Lib/site-packages


### PR DESCRIPTION
- PR #238 did migrate the code to Python 3
- The documentation mention the PYTHONPATH to Python 3.


Following this documentation https://manual.seafile.com/build_seafile/server/

I stumbled upon the problem. The PYTHONPATH as set point to 3.x while this install the modules in Python 2.7.
`libsearpc` will also need to be build with `--with-python3`. I can provide to patch to make it default.

I chose 3.5 as the version, like it is in `libsearpc`, but I didn't check it was actually sufficient.

Let me know if you have any questions.
