### PR TITLE
configure: properly install in Python 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,7 +269,7 @@ AC_SUBST(JWT_CFLAGS)
 AC_SUBST(JWT_LIBS)
 
 if test x${compile_python} = xyes; then
-    AM_PATH_PYTHON([2.6])
+    AM_PATH_PYTHON([3.5])
     if test "$bwin32" = true; then
         if test x$PYTHON_DIR != x; then
             # set pyexecdir to somewhere like /c/Python26/Lib/site-packages


### PR DESCRIPTION
- PR #238 did migrate the code to Python 3
- The documentation mention the PYTHONPATH to Python 3.


This replace #631 that was mistakenly closed by GitHub.