### PR TITLE
seaf-fsck: Skip user id check for export

### DIFF
--- a/server/gc/seaf-fsck.c
+++ b/server/gc/seaf-fsck.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
 
 #ifdef __linux__
     uid_t current_user, seafile_user;
-    if (!force && !check_user (seafile_dir, &current_user, &seafile_user)) {
+    if (!export_path && !force && !check_user (seafile_dir, &current_user, &seafile_user)) {
         seaf_message ("Current user (%u) is not the user for running "
                       "seafile server (%u). Unable to run fsck.\n",
                       current_user, seafile_user);


### PR DESCRIPTION
For export, only read access should be needed so a user UID check is not necessary. Backup restore is often done from a separate machine and it is inconvenient to require a particular user ID.