### PR TITLE
Made a Content-Disposition header case insensitive

### DIFF
--- a/server/upload-file.c
+++ b/server/upload-file.c
@@ -1869,7 +1869,7 @@ parse_mime_header (evhtp_request_t *req, char *header, RecvFSM *fsm)
     }
 
     *colon = 0;
-    if (strcmp (header, "Content-Disposition") == 0) {
+    if (strcasecmp (header, "Content-Disposition") == 0) {
         params = g_strsplit (colon + 1, ";", 3);
         for (p = params; *p != NULL; ++p)
             *p = g_strstrip (*p);


### PR DESCRIPTION
Hello,
I would like to fix a bug with the Content-Disposition header in the body of a multipart/form-data POST request.

Description of the problem:
I am using seafile API (https://download.seafile.com/published/web-api/v2.1/file-upload.md) to upload a file from SAP ERP system to Seafile.
And I encountered the "HTTP 400 Bad Request" error when sending a POST request with multipart/form-data.
After some research, I discovered that our SAP system sends the "Content-Disposition" header inside the multipart/form-data body in lower case like this: "content-disposition". And according to the HTTP standard, this is correct, since HTTP headers should not be case sensitive.
After doing this, I discovered that in the server/upload-file.c source code, the Content-Disposition header is checked using the case-sensitive function "strcmp". So my "content-disposition" header is not detected and I get an error.

Suggested solution:
So I suggest fixing this by using "strcasecmp" instead of "strcmp".

The post request from SAP system looks like this:
![image](https://github.com/haiwen/seafile-server/assets/1092110/7780df01-4e99-43fe-88b6-71b8997656d5)
