### PR TITLE
go-fileserver: Repoen error-logfile when receiving SIGHUB1

### DIFF
--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -390,7 +390,7 @@ func main() {
 	router := newHTTPRouter()
 
 	go handleSignals()
-	go handleUser1Singal()
+	go handleUser1Signal()
 
 	log.Print("Seafile file server started.")
 
@@ -409,7 +409,7 @@ func handleSignals() {
 	os.Exit(0)
 }
 
-func handleUser1Singal() {
+func handleUser1Signal() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGUSR1)
 	<-signalChan

--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -35,7 +35,7 @@ import (
 
 var dataDir, absDataDir string
 var centralDir string
-var logFile, absLogFile string
+var logFile, errorLogFile, absLogFile string
 var rpcPipePath string
 var pidFilePath string
 var logFp *os.File
@@ -357,7 +357,7 @@ func main() {
 	}
 
 	if absLogFile != "" {
-		errorLogFile := filepath.Join(filepath.Dir(absLogFile), "fileserver-error.log")
+		errorLogFile = filepath.Join(filepath.Dir(absLogFile), "fileserver-error.log")
 		fp, err := os.OpenFile(errorLogFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 		if err != nil {
 			log.Fatalf("Failed to open or create error log file: %v", err)
@@ -433,6 +433,13 @@ func logRotate() {
 		logFp.Close()
 		logFp = fp
 	}
+
+	// reopen fileserver-error log
+	fp, err = os.OpenFile(errorLogFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	if err != nil {
+		log.Fatalf("Failed to reopen fileserver-error log: %v", err)
+	}
+	syscall.Dup3(int(fp.Fd()), int(os.Stderr.Fd()), 0)
 }
 
 var rpcclient *searpc.Client


### PR DESCRIPTION
At moment, go-fileserver only reopens fileserver.log and not fileserver-error.log

Fix haiwen/seafile#2745