### PR TITLE
On notification server, get server host and port from environement if set

### DIFF
--- a/notification-server/server.go
+++ b/notification-server/server.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -45,8 +46,18 @@ func init() {
 }
 
 func loadNotifConfig() {
-	host = "0.0.0.0"
+	host := os.Getenv("NOTIFICATION_SERVER_HOST")
+	if host == "" {
+		host = "0.0.0.0"
+	}
+
 	port = 8083
+	if os.Getenv("NOTIFICATION_SERVER_PORT") != "" {
+		i, err := strconv.Atoi(os.Getenv("NOTIFICATION_SERVER_PORT"))
+		if err == nil {
+			port = i
+		}
+	}
 
 	logLevel := os.Getenv("NOTIFICATION_SERVER_LOG_LEVEL")
 	if logLevel == "" {


### PR DESCRIPTION
# Description

In some case it could be useful to specify the port to listen for the notification server.

I know that, since it's expected to be always in docker, any port is expected to work, but in some case using the whole docker environment like for the [Yunohost Seafile package](https://github.com/YunoHost-Apps/seafile_ynh) is not possible and in this case having the possibility to define the listening port is useful.

So, this change provide the possibility to also set the port and the host to listen.