### PR TITLE
add config option for multi-instance setups

### DIFF
--- a/fileserver/option/option.go
+++ b/fileserver/option/option.go
@@ -215,6 +215,9 @@ func parseFileServerSection(section *ini.Section) {
 	if key, err := section.GetKey("verify_client_blocks_after_sync"); err == nil {
 		VerifyClientBlocks, _ = key.Bool()
 	}
+	if key, err := section.GetKey("seahub_url"); err == nil {
+        	SeahubURL = key.String()
+    	}
 }
 
 func parseQuota(quotaStr string) int64 {
@@ -304,12 +307,14 @@ func LoadSeahubConfig() error {
 		return fmt.Errorf("failed to read JWT_PRIVATE_KEY")
 	}
 
-	siteRoot := os.Getenv("SITE_ROOT")
-	if siteRoot != "" {
-		SeahubURL = fmt.Sprintf("http://127.0.0.1:8000%sapi/v2.1/internal", siteRoot)
-	} else {
-		SeahubURL = "http://127.0.0.1:8000/api/v2.1/internal"
-	}
+    	if SeahubURL == "" {
+       		siteRoot := os.Getenv("SITE_ROOT")
+       		if siteRoot != "" {
+           		SeahubURL = fmt.Sprintf("http://127.0.0.1:8000%sapi/v2.1/internal", siteRoot)
+       		} else {
+           		SeahubURL = "http://127.0.0.1:8000/api/v2.1/internal"
+       		}
+   }
 
 	return nil
 }


### PR DESCRIPTION
We've been successfully using Seafile for many years, with multiple instances on one server in parallel, each running on separate fileserver ports, which worked beautifully. With Seafile 12 [1] a hardcoded SeahubURL was introduced which caused us troubles with our multi-instance deployment and might interfere with other services on a host as well. This pull request introduces a new config option in fileserver (**seahub_url**) that allows overriding the hardcoded **127.0.0.1:8000** but does not alter the code path in case the option is not set

[1] https://github.com/haiwen/seafile-server/pull/699/files/678e0dc2f51a1cadb054437760a7387c2a9877ce