### PR TITLE
GCC v15.1: Fix incompatible pointer type

### DIFF
--- a/server/upload-file.c
+++ b/server/upload-file.c
@@ -2640,8 +2640,8 @@ upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
     seaf_metric_manager_in_flight_request_inc (seaf->metric_mgr);
 
     /* Set up per-request hooks, so that we can read file data piece by piece. */
-    evhtp_set_hook (&req->hooks, evhtp_hook_on_read, upload_read_cb, fsm);
-    evhtp_set_hook (&req->hooks, evhtp_hook_on_request_fini, upload_finish_cb, fsm);
+    evhtp_set_hook (&req->hooks, evhtp_hook_on_read, (evhtp_hook)upload_read_cb, fsm);
+    evhtp_set_hook (&req->hooks, evhtp_hook_on_request_fini, (evhtp_hook)upload_finish_cb, fsm);
     /* Set arg for upload_cb or update_cb. */
     req->cbarg = fsm;
 
@@ -2889,6 +2889,7 @@ int
 upload_file_init (evhtp_t *htp, const char *http_temp_dir)
 {
     evhtp_callback_t *cb;
+    evhtp_hook upload_headers_cb = (evhtp_hook)upload_headers_cb;
 
     if (g_mkdir_with_parents (http_temp_dir, 0777) < 0) {
         seaf_warning ("Failed to create temp file dir %s.\n",


### PR DESCRIPTION
Fix compilation with `gcc (GCC) 15.1.1 20250425`.

In [Libevhtp](https://github.com/haiwen/libevhtp/blob/18c649203f009ef1d77d6f8301eba09af3777adf/evhtp.c#L2899) the function pointers are correctly casted before call, I think a pointer conversion is enough.

```
upload-file.c: In function ‘upload_headers_cb’:
upload-file.c:2639:54: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2639 |     evhtp_set_hook (&req->hooks, evhtp_hook_on_read, upload_read_cb, fsm);
      |                                                      ^~~~~~~~~~~~~~
      |                                                      |
      |                                                      evhtp_res (*)(evhtp_request_t *, evbuf_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evbuffer *, void *)}
In file included from upload-file.c:16:
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evbuf_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evbuffer *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2232:1: note: ‘upload_read_cb’ declared here
 2232 | upload_read_cb (evhtp_request_t *req, evbuf_t *buf, void *arg)
      | ^~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c:2640:62: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2640 |     evhtp_set_hook (&req->hooks, evhtp_hook_on_request_fini, upload_finish_cb, fsm);
      |                                                              ^~~~~~~~~~~~~~~~
      |                                                              |
      |                                                              evhtp_res (*)(evhtp_request_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:1837:1: note: ‘upload_finish_cb’ declared here
 1837 | upload_finish_cb (evhtp_request_t *req, void *arg)
      | ^~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c: In function ‘upload_file_init’:
upload-file.c:2905:55: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2905 |     evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
      |                                                       ^~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2542:1: note: ‘upload_headers_cb’ declared here
 2542 | upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
      | ^~~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c:2909:55: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2909 |     evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
      |                                                       ^~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2542:1: note: ‘upload_headers_cb’ declared here
 2542 | upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
      | ^~~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c:2912:55: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2912 |     evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
      |                                                       ^~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2542:1: note: ‘upload_headers_cb’ declared here
 2542 | upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
      | ^~~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c:2918:55: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2918 |     evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
      |                                                       ^~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2542:1: note: ‘upload_headers_cb’ declared here
 2542 | upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
      | ^~~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c:2921:55: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2921 |     evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
      |                                                       ^~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2542:1: note: ‘upload_headers_cb’ declared here
 2542 | upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
      | ^~~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c:2924:55: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2924 |     evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
      |                                                       ^~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2542:1: note: ‘upload_headers_cb’ declared here
 2542 | upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
      | ^~~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
upload-file.c:2930:55: error: passing argument 3 of ‘evhtp_set_hook’ from incompatible pointer type [-Wincompatible-pointer-types]
 2930 |     evhtp_set_hook(&cb->hooks, evhtp_hook_on_headers, upload_headers_cb, NULL);
      |                                                       ^~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *) {aka short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)}
/usr/include/evhtp.h:630:77: note: expected ‘evhtp_hook’ {aka ‘short unsigned int (*)(void)’} but argument is of type ‘evhtp_res (*)(evhtp_request_t *, evhtp_kvs_t *, void *)’ {aka ‘short unsigned int (*)(struct evhtp_request_s *, struct evhtp_kvs_s *, void *)’}
  630 | int evhtp_set_hook(evhtp_hooks_t ** hooks, evhtp_hook_type type, evhtp_hook cb, void * arg);
      |                                                                  ~~~~~~~~~~~^~
upload-file.c:2542:1: note: ‘upload_headers_cb’ declared here
 2542 | upload_headers_cb (evhtp_request_t *req, evhtp_headers_t *hdr, void *arg)
      | ^~~~~~~~~~~~~~~~~
/usr/include/evhtp.h:138:21: note: ‘evhtp_hook’ declared here
  138 | typedef evhtp_res (*evhtp_hook)();
      |                     ^~~~~~~~~~
```