### PR TITLE
obj-cache: make objcache_new prototype match definition and call site

### DIFF
--- a/common/obj-cache.c
+++ b/common/obj-cache.c
@@ -70,7 +70,7 @@ load_cache_option_from_env (CacheOption *option)
 }
 
 ObjCache *
-objcache_new (GKeyFile *config)
+objcache_new (void)
 {
     ObjCache *cache = NULL;
     GError *error = NULL;

--- a/common/obj-cache.h
+++ b/common/obj-cache.h
@@ -43,7 +43,7 @@ struct ObjCache {
 };
 
 ObjCache *
-objcache_new ();
+objcache_new (void);
 
 void *
 objcache_get_object (struct ObjCache *cache, const char *obj_id, size_t *len);


### PR DESCRIPTION
_Disclaimer: Patch was created with help of AI, feel free to close without comment if invalid._


The header declares `objcache_new()` with an empty (K&R) parameter list, the definition takes `GKeyFile *config`, and the only caller (`server/seafile-session.c`) passes no argument. The parameter is unused — cache options are read from the environment — so this drops it and declares `(void)` explicitly.

Under C23, the default for GCC 15 (Ubuntu 26.04, Fedora 42+, Debian forky), an empty parameter list means `(void)`, which turns the current mismatch into a hard compile error:

```text
obj-cache.c:73:1: error: conflicting types for 'objcache_new'; have 'ObjCache *(GKeyFile *)'
seafile-session.c:141:26: error: too few arguments to function 'objcache_new'; expected 1, have 0
```

Verified against gcc 15.2: the tree compiles cleanly with this change. No functional change.

Related: #758 addresses a different instance of the same C23 transition (the `evhtp_set_hook` callback casts in upload-file.c); this fix is independent of it.
